### PR TITLE
Correcting mock tests in integration tests

### DIFF
--- a/shipping_order_service/test/test_integration_shipping/test_create_shipping_order.py
+++ b/shipping_order_service/test/test_integration_shipping/test_create_shipping_order.py
@@ -6,11 +6,16 @@ from httpx._transports.asgi import ASGITransport
 @pytest.mark.asyncio
 async def test_create_shipping_order_integration(mocker):
     # Mock the tracking service client
-    mock_tracking_dict_response = {'mock_tracking_status': 'event_sent'}
+    mock_tracking_response = Response(201, json={
+        'order_id': 'mocked-order-123',
+        'tracking_code': 'mocked-tracking-123',
+        'status': 'created',
+        'mock_tracking_status': 'event_sent'
+    })
     mocker.patch(
         'app.services.tracking_service_client.httpx.AsyncClient.post', # Corrected path
         new_callable=mocker.AsyncMock,
-        return_value=mock_tracking_dict_response # Changed to a dict
+        return_value=mock_tracking_response
     )
 
     transport = ASGITransport(app=app)

--- a/shipping_order_service/test/test_integration_shipping/test_track_order_code.py
+++ b/shipping_order_service/test/test_integration_shipping/test_track_order_code.py
@@ -6,11 +6,16 @@ from httpx._transports.asgi import ASGITransport
 @pytest.mark.asyncio
 async def test_track_shipping_order_by_code(mocker):
     # Mock the tracking service client for POST (order creation)
-    mock_tracking_dict_response = {'mock_tracking_status': 'event_sent'}
+    mock_tracking_response = Response(201, json={
+        'order_id': 'mocked-order-123',
+        'tracking_code': 'mocked_tracking_code_from_post',
+        'status': 'created',
+        'mock_tracking_status': 'event_sent'
+    })
     mocker.patch(
         'app.services.tracking_service_client.httpx.AsyncClient.post', # Corrected path
         new_callable=mocker.AsyncMock,
-        return_value=mock_tracking_dict_response # Changed to a dict
+        return_value=mock_tracking_response
     )
 
     # Mock the tracking service client for GET (order tracking)


### PR DESCRIPTION
Los tests de integración estaban fallando debido a dos problemas principales:
Problema inicial: Los mocks devolvían diccionarios simples en lugar de objetos tipo Response de httpx, lo que causaba errores como:
AttributeError: 'dict' object has no attribute 'json'
AttributeError: 'dict' object has no attribute 'status_code'
Problema secundario: Una vez corregido el primer problema, los mocks no simulaban correctamente:
Los códigos de estado HTTP esperados (204 para cancelaciones y actualizaciones )
La estructura de datos esperada en las respuestas JSON
El flujo de negocio entre diferentes operaciones
Solución Implementada
Reemplazo de diccionarios por objetos Response:
Se modificaron todos los mocks para devolver objetos Response en lugar de diccionarios simples
Se utilizó el constructor Response(status_code, json={...}) para crear respuestas adecuadas