### PR TITLE
Fix: Address use_build_context_synchronously and Android embedding

### DIFF
--- a/front-end/logistic_app/android/build.gradle.kts
+++ b/front-end/logistic_app/android/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    id("com.android.application") version "8.2.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.20" apply false
+    id("dev.flutter.flutter-gradle-plugin") version "1.0.0" apply false
+}
+
 allprojects {
     repositories {
         google()
@@ -12,9 +18,9 @@ subprojects {
     val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
     project.layout.buildDirectory.value(newSubprojectBuildDir)
 }
-subprojects {
-    project.evaluationDependsOn(":app")
-}
+// subprojects {
+//     project.evaluationDependsOn(":app")
+// } // This line is removed as per instructions
 
 tasks.register<Delete>("clean") {
     description = "Elimina el directorio de construcción de todos los proyectos"

--- a/front-end/logistic_app/lib/screens/routes_screen.dart
+++ b/front-end/logistic_app/lib/screens/routes_screen.dart
@@ -158,7 +158,10 @@ class _RoutesScreenState extends State<RoutesScreen> {
                         style: ElevatedButton.styleFrom(backgroundColor: Colors.green),
                         onPressed: () async {
                           final String routeId = route['id'];
-                          final BuildContext detailsDialogContext = context; // Capture context
+                          // final BuildContext detailsDialogContext = context; // Capture context
+                          if (!mounted) return;
+                          final scaffoldMessenger = ScaffoldMessenger.of(this.context);
+                          final dialogNavigator = Navigator.of(context);
 
                           try {
                             final uri = Uri.parse('http://localhost:8004/routes/$routeId/complete');
@@ -169,23 +172,33 @@ class _RoutesScreenState extends State<RoutesScreen> {
                             if (!mounted) return;
 
                             // Pop dialog first
-                            Navigator.of(detailsDialogContext).pop();
+                            // Navigator.of(detailsDialogContext).pop();
+                            if (mounted) dialogNavigator.pop();
 
                             if (response.statusCode == 200) {
                               fetchRoutes(); // Refresh list
                               if (!mounted) return; // Check mounted again before using this.context
-                              ScaffoldMessenger.of(this.context).showSnackBar(
+                              // ScaffoldMessenger.of(this.context).showSnackBar(
+                              //   const SnackBar(content: Text('Ruta marcada como completada')),
+                              // );
+                              if (mounted) scaffoldMessenger.showSnackBar(
                                 const SnackBar(content: Text('Ruta marcada como completada')),
                               );
                             } else {
                               if (!mounted) return;
-                              ScaffoldMessenger.of(this.context).showSnackBar(
+                              // ScaffoldMessenger.of(this.context).showSnackBar(
+                              //   SnackBar(content: Text('Error al completar ruta: ${response.body}')),
+                              // );
+                              if (mounted) scaffoldMessenger.showSnackBar(
                                 SnackBar(content: Text('Error al completar ruta: ${response.body}')),
                               );
                             }
                           } catch (e) {
-                            if (!mounted) return;
-                            ScaffoldMessenger.of(context).showSnackBar(
+                            // if (!mounted) return;
+                            // ScaffoldMessenger.of(context).showSnackBar(
+                            //   SnackBar(content: Text('Error de conexión al completar ruta: $e')),
+                            // );
+                            if (mounted) scaffoldMessenger.showSnackBar( // Assuming context here refers to the State's context due to scaffoldMessenger definition
                               SnackBar(content: Text('Error de conexión al completar ruta: $e')),
                             );
                           }
@@ -249,6 +262,9 @@ class _RoutesScreenState extends State<RoutesScreen> {
 
       // Capture the context for use after async operations if mounted
       final currentContext = context; // Assuming 'context' is the BuildContext of _showDriverSelectionDialog
+      if (!mounted) return;
+      final scaffoldMessenger = ScaffoldMessenger.of(this.context);
+      final dialogNavigator = Navigator.of(currentContext);
 
       try {
         final uri = Uri.parse('http://localhost:8004/routes/$routeId/driver');
@@ -268,9 +284,10 @@ class _RoutesScreenState extends State<RoutesScreen> {
         // or rely on the try-catch to handle cases where context might be invalid.
 
           if (response.statusCode == 200) { // Backend now returns 200 with updated route
-          if (!Navigator.of(currentContext).mounted) return; // Check before using context
+          // if (!Navigator.of(currentContext).mounted) return; // Check before using context
           // ignore: use_build_context_synchronously
-          Navigator.of(currentContext).pop(selectedDriver); // Close driver selection dialog, pass back selected driver
+          // Navigator.of(currentContext).pop(selectedDriver); // Close driver selection dialog, pass back selected driver
+          if (mounted) dialogNavigator.pop(selectedDriver);
           
           // Potentially pop the details dialog as well, or let the caller handle it.
           // For now, just pop the selection dialog.
@@ -278,19 +295,28 @@ class _RoutesScreenState extends State<RoutesScreen> {
 
           if (!mounted) return; // Check before using context for ScaffoldMessenger
           // ignore: use_build_context_synchronously
-          ScaffoldMessenger.of(context).showSnackBar(
+          // ScaffoldMessenger.of(context).showSnackBar(
+          //   const SnackBar(content: Text('Conductor asignado a la ruta.')),
+          // );
+          if (mounted) scaffoldMessenger.showSnackBar(
             const SnackBar(content: Text('Conductor asignado a la ruta.')),
           );
           fetchRoutes(); // Refresh the routes list on the main screen
         } else {
           if (!mounted) return; // Check before using context for ScaffoldMessenger
-          ScaffoldMessenger.of(context).showSnackBar(
+          // ScaffoldMessenger.of(context).showSnackBar(
+          //   SnackBar(content: Text('Error al asignar conductor: ${response.body} (Status: ${response.statusCode})')),
+          // );
+          if (mounted) scaffoldMessenger.showSnackBar(
             SnackBar(content: Text('Error al asignar conductor: ${response.body} (Status: ${response.statusCode})')),
           );
         }
       } catch (e) {
         if (!mounted) return; // Check before using context for ScaffoldMessenger
-        ScaffoldMessenger.of(context).showSnackBar(
+        // ScaffoldMessenger.of(context).showSnackBar(
+        //   SnackBar(content: Text('Error de conexión al asignar conductor: $e')),
+        // );
+        if (mounted) scaffoldMessenger.showSnackBar(
           SnackBar(content: Text('Error de conexión al asignar conductor: $e')),
         );
       }


### PR DESCRIPTION
- I refactored `_showRouteDetails` and `_showDriverSelectionDialog` in `lib/screens/routes_screen.dart` to correctly handle BuildContext across asynchronous gaps. This resolves the `use_build_context_synchronously` lint warning by caching Navigator and ScaffoldMessenger instances before await calls and using them with `mounted` checks.

- I updated `android/build.gradle.kts` (project-level) to define explicit versions for the Android Gradle Plugin (8.2.0) and Kotlin (1.9.20). The project was already mostly configured for Android V2 embedding (flutterEmbedding=2 meta-data was present, and MainActivity extended FlutterActivity), so this change primarily modernizes the build setup. This is expected to resolve the warning about deprecated Android embedding.

Note: I was unable to run `flutter analyze` in the automated environment to confirm the fix directly.